### PR TITLE
Navigation suggestions

### DIFF
--- a/detail.html
+++ b/detail.html
@@ -50,7 +50,7 @@
                 </li>
             </ul>
         </nav>
-        <main class="detail-page">
+        <main id="main" class="detail-page">
             <h1>Heading H1</h1>
                 <p>Hardwired professional deficiency BAMA quicksilver sanpaku cutting-edge cryptic dub aimi lorem gibson.</p>
             <h2>Heading H2</h2>

--- a/index.html
+++ b/index.html
@@ -58,163 +58,165 @@
                 <img src="lib/img/aa-visual-header.svg" alt="Architecture Antipattern Keyvisual" class="landingpage-header__keyvisual" />
             </div>
         </header>
-        <section id="teaser-antipatterns" class="stripe stripe--grey">
-            <div class="landingpage-teaser-section__wrapper">
-                <h2 class="landingpage-teaser-section__title landingpage-teaser-section__title--purple">Antipatterns</h2>
-                <div class="landingpage-teaser-section__grid">
-                    <div class="teaser-card teaser-card--purple">
-                        <div class="teaser-card__body">
-                            <h3 class="teaser-card__title">Overengineering</h3>
-                            <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lore Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            </p>
+        <main id="main">
+            <section id="teaser-antipatterns" class="stripe stripe--grey">
+                <div class="landingpage-teaser-section__wrapper">
+                    <h2 class="landingpage-teaser-section__title landingpage-teaser-section__title--purple">Antipatterns</h2>
+                    <div class="landingpage-teaser-section__grid">
+                        <div class="teaser-card teaser-card--purple">
+                            <div class="teaser-card__body">
+                                <h3 class="teaser-card__title">Overengineering</h3>
+                                <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lore Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                </p>
+                            </div>
+                            <div class="teaser-card__footer teaser-card_footer--purple">
+                                <a class="teaser-card__button teaser-card__button--purple" href="https://www.innoq.com">Read more</a>
+                            </div>
                         </div>
-                        <div class="teaser-card__footer teaser-card_footer--purple">
-                            <a class="teaser-card__button teaser-card__button--purple" href="https://www.innoq.com">Read more</a>
+                        <div class="teaser-card teaser-card--purple">
+                            <div class="teaser-card__body">
+                                <h3 class="teaser-card__title">Domain Allergy</h3>
+                                <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                </p>
+                            </div>
+                            <div class="teaser-card__footer teaser-card_footer--purple">
+                                <a class="teaser-card__button teaser-card__button--purple" href="https://www.innoq.com">Read more</a>
+                            </div>
                         </div>
-                    </div>
-                    <div class="teaser-card teaser-card--purple">
-                        <div class="teaser-card__body">
-                            <h3 class="teaser-card__title">Domain Allergy</h3>
-                            <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            </p>
+                        <div class="teaser-card teaser-card--purple">
+                            <div class="teaser-card__body">
+                                <h3 class="teaser-card__title">Cargo Culting</h3>
+                                <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum</p>
+                            </div>
+                            <div class="teaser-card__footer teaser-card_footer--purple">
+                                <a class="teaser-card__button teaser-card__button--purple" href="https://www.innoq.com">Read more</a>
+                            </div>
                         </div>
-                        <div class="teaser-card__footer teaser-card_footer--purple">
-                            <a class="teaser-card__button teaser-card__button--purple" href="https://www.innoq.com">Read more</a>
-                        </div>
-                    </div>
-                    <div class="teaser-card teaser-card--purple">
-                        <div class="teaser-card__body">
-                            <h3 class="teaser-card__title">Cargo Culting</h3>
-                            <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum</p>
-                        </div>
-                        <div class="teaser-card__footer teaser-card_footer--purple">
-                            <a class="teaser-card__button teaser-card__button--purple" href="https://www.innoq.com">Read more</a>
-                        </div>
-                    </div>
-                    <div class="teaser-card teaser-card--purple">
-                        <div class="teaser-card__body">
-                            <h3 class="teaser-card__title">Misattachment</h3>
-                            <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum</p>
-                        </div>
-                        <div class="teaser-card__footer teaser-card_footer--purple">
-                            <a class="teaser-card__button teaser-card__button--purple" href="https://www.innoq.com">Read more</a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </section>
-        <section id="teaser-casestudies" class="stripe stripe--white">
-            <div class="landingpage-teaser-section__wrapper">
-                <h2 class="landingpage-teaser-section__title landingpage-teaser-section__title--blue">Case Studies and Examples</h2>
-                <div class="landingpage-teaser-section__grid">
-                    <div class="teaser-card teaser-card--blue">
-                        <div class="teaser-card__body">
-                            <h3 class="teaser-card__title">Super-generic framework in logistics</h3>
-                            <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            </p>
-                        </div>
-                        <div class="teaser-card__footer teaser-card_footer--blue">
-                            <a class="teaser-card__button teaser-card__button--blue" href="https://www.innoq.com">Read more</a>
-                        </div>
-                    </div>
-                    <div class="teaser-card teaser-card--blue">
-                        <div class="teaser-card__body">
-                            <h3 class="teaser-card__title">Over-configurability in a (huuuuge) commerce system</h3>
-                            <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            </p>
-                        </div>
-                        <div class="teaser-card__footer teaser-card_footer--blue">
-                            <a class="teaser-card__button teaser-card__button--blue" href="https://www.innoq.com">Read more</a>
-                        </div>
-                    </div>
-                    <div class="teaser-card teaser-card--blue">
-                        <div class="teaser-card__body">
-                            <h3 class="teaser-card__title">The insurance app productline for 100+ countries</h3>
-                            <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            </p>
-                        </div>
-                        <div class="teaser-card__footer teaser-card_footer--blue">
-                            <a class="teaser-card__button teaser-card__button--blue" href="https://www.innoq.com">Read more</a>
-                        </div>
-                    </div>
-                    <div class="teaser-card teaser-card--blue">
-                        <div class="teaser-card__body">
-                            <h3 class="teaser-card__title">Two huge domain classes represent all legal forms for companies, unions and foundations</h3>
-                            <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            </p>
-                        </div>
-                        <div class="teaser-card__footer teaser-card_footer--blue">
-                            <a class="teaser-card__button teaser-card__button--blue" href="https://www.innoq.com">Read more</a>
+                        <div class="teaser-card teaser-card--purple">
+                            <div class="teaser-card__body">
+                                <h3 class="teaser-card__title">Misattachment</h3>
+                                <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum</p>
+                            </div>
+                            <div class="teaser-card__footer teaser-card_footer--purple">
+                                <a class="teaser-card__button teaser-card__button--purple" href="https://www.innoq.com">Read more</a>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-        </section>
-        <section id="author-section" class="stripe stripe--purple">
-            <div class="landingpage-teaser-section__wrapper">
-                <h2 class="landingpage-teaser-section__title landingpage-teaser-section__title--white">Maintainers</h2>
-                <div class="landingpage-teaser-section__grid">
-                    <div class="author__card">
-                        <div class="author-card__header">
-                            <img src="lib/img/christian-jacobs-ava.webp" alt="Avatar Felix Schumacher" class="author-card__avatar" />
-                            <h3 class="author-card__title">Christian Jacobs</h3>
-                            <p class="author-card__twitterhandle">@christian_on_twitter</p>
+            </section>
+            <section id="teaser-casestudies" class="stripe stripe--white">
+                <div class="landingpage-teaser-section__wrapper">
+                    <h2 class="landingpage-teaser-section__title landingpage-teaser-section__title--blue">Case Studies and Examples</h2>
+                    <div class="landingpage-teaser-section__grid">
+                        <div class="teaser-card teaser-card--blue">
+                            <div class="teaser-card__body">
+                                <h3 class="teaser-card__title">Super-generic framework in logistics</h3>
+                                <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                </p>
+                            </div>
+                            <div class="teaser-card__footer teaser-card_footer--blue">
+                                <a class="teaser-card__button teaser-card__button--blue" href="https://www.innoq.com">Read more</a>
+                            </div>
                         </div>
-                        <div class="author-card__body">
-                            <p class="author-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem
-                                psum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                            </p>
+                        <div class="teaser-card teaser-card--blue">
+                            <div class="teaser-card__body">
+                                <h3 class="teaser-card__title">Over-configurability in a (huuuuge) commerce system</h3>
+                                <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                </p>
+                            </div>
+                            <div class="teaser-card__footer teaser-card_footer--blue">
+                                <a class="teaser-card__button teaser-card__button--blue" href="https://www.innoq.com">Read more</a>
+                            </div>
                         </div>
-                    </div>
-                    <div class="author__card">
-                        <div class="author-card__header">
-                            <img src="lib/img/theo-pack-ava.webp" alt="Avatar Theo Pack" class="author-card__avatar" />
-                            <h3 class="author-card__title">Theo Pack</h3>
-                            <p class="author-card__twitterhandle">@theo_on_twitter</p>
+                        <div class="teaser-card teaser-card--blue">
+                            <div class="teaser-card__body">
+                                <h3 class="teaser-card__title">The insurance app productline for 100+ countries</h3>
+                                <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                </p>
+                            </div>
+                            <div class="teaser-card__footer teaser-card_footer--blue">
+                                <a class="teaser-card__button teaser-card__button--blue" href="https://www.innoq.com">Read more</a>
+                            </div>
                         </div>
-                        <div class="author-card__body">
-                            <p class="author-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem
-                                psum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem
-                                Ipsum
-                            </p>
-                        </div>
-                    </div>
-                    <div class="author__card">
-                        <div class="author-card__header">
-                            <img src="lib/img/felix-schumacher-ava.webp" alt="Avatar Felix Schumacher" class="author-card__avatar" />
-                            <h3 class="author-card__title">Felix Schumacher</h3>
-                            <p class="author-card__twitterhandle">@felix_on_twitter</p>
-                        </div>
-                        <div class="author-card__body">
-                            <p class="author-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
-                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem
-                                psum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem
-                                Ipsum
-                            </p>
+                        <div class="teaser-card teaser-card--blue">
+                            <div class="teaser-card__body">
+                                <h3 class="teaser-card__title">Two huge domain classes represent all legal forms for companies, unions and foundations</h3>
+                                <p class="teaser-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                </p>
+                            </div>
+                            <div class="teaser-card__footer teaser-card_footer--blue">
+                                <a class="teaser-card__button teaser-card__button--blue" href="https://www.innoq.com">Read more</a>
+                            </div>
                         </div>
                     </div>
                 </div>
-            </div>
-        </section>
+            </section>
+            <section id="author-section" class="stripe stripe--purple">
+                <div class="landingpage-teaser-section__wrapper">
+                    <h2 class="landingpage-teaser-section__title landingpage-teaser-section__title--white">Maintainers</h2>
+                    <div class="landingpage-teaser-section__grid">
+                        <div class="author__card">
+                            <div class="author-card__header">
+                                <img src="lib/img/christian-jacobs-ava.webp" alt="Avatar Felix Schumacher" class="author-card__avatar" />
+                                <h3 class="author-card__title">Christian Jacobs</h3>
+                                <p class="author-card__twitterhandle">@christian_on_twitter</p>
+                            </div>
+                            <div class="author-card__body">
+                                <p class="author-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                    Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem
+                                    psum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                </p>
+                            </div>
+                        </div>
+                        <div class="author__card">
+                            <div class="author-card__header">
+                                <img src="lib/img/theo-pack-ava.webp" alt="Avatar Theo Pack" class="author-card__avatar" />
+                                <h3 class="author-card__title">Theo Pack</h3>
+                                <p class="author-card__twitterhandle">@theo_on_twitter</p>
+                            </div>
+                            <div class="author-card__body">
+                                <p class="author-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                    Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem
+                                    psum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem
+                                    Ipsum
+                                </p>
+                            </div>
+                        </div>
+                        <div class="author__card">
+                            <div class="author-card__header">
+                                <img src="lib/img/felix-schumacher-ava.webp" alt="Avatar Felix Schumacher" class="author-card__avatar" />
+                                <h3 class="author-card__title">Felix Schumacher</h3>
+                                <p class="author-card__twitterhandle">@felix_on_twitter</p>
+                            </div>
+                            <div class="author-card__body">
+                                <p class="author-card__text">Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum
+                                    Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem
+                                    psum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem Ipsum Lorem
+                                    Ipsum
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+        </main>
         </body>
         <footer class="footer footer--black">
             <div class="footer__wrapper">

--- a/styles/components-lists.css
+++ b/styles/components-lists.css
@@ -5,8 +5,8 @@ ul {
   list-style-position: outside;
 }
 
-ul > * + *,
-ol > * + * {
+ul:not([class]) > * + *,
+ol:not([class]) > * + * {
   margin-top: var(--spacer-xxs);
 }
 

--- a/styles/components-nav.css
+++ b/styles/components-nav.css
@@ -291,10 +291,10 @@
 /* Breakpoints */
 @media (min-width: 925px) {
   .main-navigation {
-    --navbar-toggler-width: var(--forced-colors-navbar-toggler-width, calc((2px * 2) + (24px * 3)));
+    --navbar-margin-width: calc((100% - var(--content-width-xl)) / 2);
 
-    grid-template-areas: 'brand nav nav nav';
-    grid-template-columns: var(--navbar-toggler-width) 1fr 1fr 1fr var(--navbar-toggler-width);
+    grid-template-areas: '. brand nav .';
+    grid-template-columns: var(--navbar-margin-width) min-content 1fr var(--navbar-margin-width);
   }
 
   .main-navigation .brand-link {
@@ -307,9 +307,15 @@
 
   .main-navigation .navigation-links {
     display: flex;
-    justify-content: center;
+    justify-content: flex-end;
     padding: 0 12px;
     background-color: var(--brand-black);
+    gap: 24px;
+  }
+
+  .main-navigation .navigation-links li {
+    display: flex;
+    justify-content: center;
   }
 
   .main-navigation .navigation-links a {
@@ -327,6 +333,7 @@
     margin-top: 0;
   }
 
+  .main-navigation .navigation-links > :nth-last-child(2),
   .main-navigation .navigation-links > :last-child {
     --submenu-position-right: 0;
 
@@ -354,6 +361,7 @@
 
   .main-navigation sub-menu > button {
     grid-area: button;
+    align-self: end;
   }
 
   .main-navigation sub-menu > div {
@@ -401,19 +409,6 @@
   }
 }
 
-@media (min-width: 90.25rem) {
-  .main-navigation {
-    grid-template-areas: 'brand . . nav nav nav';
-    grid-template-columns:
-      1fr var(--navbar-toggler-width) calc((90.25rem - 10rem - var(--navbar-toggler-width) * 2) * 0.5)
-      10rem calc((90.25rem - 10rem - var(--navbar-toggler-width) * 2) * 0.5) var(--navbar-toggler-width) 1fr;
-  }
-
-  .main-navigation .navigation-links {
-    gap: 24px;
-  }
-}
-
 /* Accessibility */
 @media (prefers-reduced-motion: no-preference) {
   .main-navigation {
@@ -427,7 +422,6 @@
     --forced-colors-link-border-width: 0;
     --forced-colors-action-margin: 2px;
     --forced-colors-link-decoration: underline;
-    --forced-colors-navbar-toggler-width: 10rem;
   }
 
   .main-navigation .link-alt {

--- a/styles/components-nav.css
+++ b/styles/components-nav.css
@@ -84,6 +84,7 @@
 .main-navigation .brand-link:focus,
 .skip-link:focus {
   color: var(--brand-blue1);
+  border-color: var(--brand-white);
   outline: 2px solid var(--brand-black);
 }
 
@@ -96,6 +97,7 @@
 .main-navigation .brand-link:focus-visible,
 .skip-link:focus-visible {
   color: var(--brand-blue1);
+  border-color: var(--brand-white);
   outline: 2px solid var(--brand-black);
 }
 


### PR DESCRIPTION
This merge request contains 4 suggestions (which can be seen in this branch as 4 separate commits):

[fixed misaligned navigation items](https://github.com/innoq/architecture-antipatterns-website/commit/4c6ee979698a0e1907a85cffbda2f02964fecfa9)

This changes the default styling for lists so that adding spacing between list items only occurs when we have _not_ set
a `class` attribute for the list. This means that we assume that if we are setting a `class` attribute on a list, this
means that we are adding extra styling to the list, and so we should not specify our default spacing between list
elements in this case.

[fixed accessibility of skip link by adding main tag with proper `id…](https://github.com/innoq/architecture-antipatterns-website/commit/eee8fef7186a06d3353ea2b0213e8be68a2aee83)

…` attribute

This fixes the accessibility of the skip link. The idea behind the skip link is that if a user is navigating with a
keyboard and the skip link is focussed, they can hit ENTER to click on the link and thereby skip over the header with
any long navigation.

However, this also means that we need to ensure that there is a valid target on the page that the user can spring to. We
do this by wrapping all of our content in a `main` element (which also improves the accessibility because it adds a
landmark for the main content) and by adding the `id` to the `main` that the link references (in this case, the link
points to `#main`, so we want to make sure that we have a `main` element with a `main` id).

[add layout for navbar](https://github.com/innoq/architecture-antipatterns-website/commit/aa53ff8cea0a10fbbcd56868b9cb5053147e051a)

This adds some rules to the CSS layout to position the navbar on desktop.
The layout is pretty much the same in every "desktop" viewport, with the
logo positioned in the upper lefthand side, and the menu items shown on the
right of the navbar. Because of this, we only need one breakpoint to specify this layout.

We can define the `grid-template-columns` of the layout to be:
`var(--navbar-margin-width) min-content 1fr var(--navbar-margin-width)` and we define
the `--navbar-margin-width` to be:
`calc((100% - var(--content-width-xl))/ 2)`

When the viewport is smaller than `--content-width-xl`, the left and right column in
the grid layout will calculate to 0 (since `100% - var(--content-width-xl)` is negative).
When the viewport is larger than `--content-width-xl`, the `--navbar-margin-width` calculate
will activate and that causes the navbar to be centered over the content area.

This also adds a few rules for centering the navigation items vertically within the navbar.

[fix focus styles for navbar](https://github.com/innoq/architecture-antipatterns-website/commit/ac2c91837dd50bf80543eec18949799c58d39014)

When navigating with a keyboard, the focus styles were broken because the outline color is black and the background of
the navbar is black (e.g. there is no contrast between them). By setting the border color to be white, we add an extra
white ring around the focussable items to ensure that the focus ring can be seen whenever it should be visible.


If any of the changes are unclear, please don't hesitate to ask!
